### PR TITLE
Improve popup on narrow displays

### DIFF
--- a/daily-schedule-card.js
+++ b/daily-schedule-card.js
@@ -5,7 +5,6 @@ class DailyScheduleCard extends HTMLElement {
       return;
     }
     if (!this._dialog) {
-      this._getInputTimeWidth();
       this._createDialog();
       this.appendChild(this._dialog);
     }
@@ -336,8 +335,7 @@ class DailyScheduleCard extends HTMLElement {
     };
 
     Object.assign(time_input.style, {
-      width: `${this._input_time_width}px`,
-      minWidth: `${this._input_time_width}px`,
+      minWidth: "fit-content",
       boxSizing: "border-box",
       padding: "4px 0",
       cursor: "pointer",
@@ -387,19 +385,6 @@ class DailyScheduleCard extends HTMLElement {
         input.value = null;
       }
       symbol.icon = "mdi:clock-outline";
-    }
-  }
-
-  _getInputTimeWidth() {
-    if (!this._input_time_width) {
-      const dummyInput = document.createElement("INPUT");
-      dummyInput.type = "time";
-      dummyInput.style.visibility = "hidden";
-      this.appendChild(dummyInput);
-      setTimeout(() => {
-        this._input_time_width = dummyInput.getBoundingClientRect().width;
-        this.removeChild(dummyInput);
-      }, 0);
     }
   }
 

--- a/daily-schedule-card.js
+++ b/daily-schedule-card.js
@@ -278,8 +278,8 @@ class DailyScheduleCard extends HTMLElement {
     this._createTimeInput(range, "to", row);
 
     const toggle = document.createElement("ha-switch");
-    toggle.style.marginLeft = "auto";
-    toggle.style.paddingLeft = "16px";
+    toggle.style.margin = "0 auto";
+    toggle.style.paddingLeft = "8px";
     toggle.checked = !range.disabled;
     toggle.addEventListener("change", () => {
       range.disabled = !range.disabled;


### PR DESCRIPTION
`min-width: fit-content` should be enough for all scenarios, instead of having to resort to pixel math. That's [available "everywhere"](https://caniuse.com/mdn-css_properties_min-width_fit-content) nowadays.

----

I got confused today when I wanted to switch some time slots... and realized there were no buttons there. I haven't done that in quite some time, so I was wondering if I was on the wrong screen. Some time later I tried the same from my computer and they were there! Then I realized there was horizontal scrolling on my phone (Z Fold 6) :joy:

![image](https://github.com/user-attachments/assets/5beddd07-c38e-404a-a66b-be338a5c2860)

Here's how this change shows on a real device, using the device inspector, editing the first row only:
![image](https://github.com/user-attachments/assets/e095d111-8cb2-4cbf-ac21-576ba2e30870)

And the same change on a wider screen (landscape):
![image](https://github.com/user-attachments/assets/63dde931-2718-4e14-99b2-cb5f1ed16dd8)
![image](https://github.com/user-attachments/assets/584bbd46-bb9c-4168-aff9-2bdbf86106d5)
